### PR TITLE
Add Altair fork epoch of 61650 for Pyrmont

### DIFF
--- a/shared/pyrmont/config.yaml
+++ b/shared/pyrmont/config.yaml
@@ -3,9 +3,6 @@
 # Extends the mainnet preset
 PRESET_BASE: 'mainnet'
 
-# For backwards compatibility in the config/spec API
-CONFIG_NAME: "pyrmont"
-
 # Genesis
 # ---------------------------------------------------------------
 # `2**14` (= 16,384)

--- a/shared/pyrmont/config.yaml
+++ b/shared/pyrmont/config.yaml
@@ -1,153 +1,75 @@
-# Pyrmont preset
+# Pyrmont config
 
-# Misc
+# Extends the mainnet preset
+PRESET_BASE: 'mainnet'
+
+# For backwards compatibility in the config/spec API
+CONFIG_NAME: "pyrmont"
+
+# Genesis
 # ---------------------------------------------------------------
-# 2**6 (= 64)
-MAX_COMMITTEES_PER_SLOT: 64
-# 2**7 (= 128)
-TARGET_COMMITTEE_SIZE: 128
-# 2**11 (= 2,048)
-MAX_VALIDATORS_PER_COMMITTEE: 2048
-# 2**2 (= 4)
-MIN_PER_EPOCH_CHURN_LIMIT: 4
-# 2**16 (= 65,536)
-CHURN_LIMIT_QUOTIENT: 65536
-# See issue 563
-SHUFFLE_ROUND_COUNT: 90
 # `2**14` (= 16,384)
 MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 16384
 # Nov 18, 2020, 12pm UTC
 MIN_GENESIS_TIME: 1605700800
-# 4
-HYSTERESIS_QUOTIENT: 4
-# 1 (minus 0.25)
-HYSTERESIS_DOWNWARD_MULTIPLIER: 1
-# 5 (plus 1.25)
-HYSTERESIS_UPWARD_MULTIPLIER: 5
-
-
-# Fork Choice
-# ---------------------------------------------------------------
-# 2**3 (= 8)
-SAFE_SLOTS_TO_UPDATE_JUSTIFIED: 8
-
-
-# Validator
-# ---------------------------------------------------------------
-# 2**11 (= 2,048)
-ETH1_FOLLOW_DISTANCE: 2048
-# 2**4 (= 16)
-TARGET_AGGREGATORS_PER_COMMITTEE: 16
-# 2**0 (= 1)
-RANDOM_SUBNETS_PER_VALIDATOR: 1
-# 2**8 (= 256)
-EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION: 256
-# 14 (estimate from Eth1 mainnet)
-SECONDS_PER_ETH1_BLOCK: 14
-
-
-# Deposit contract
-# ---------------------------------------------------------------
-# Ethereum Goerli testnet
-DEPOSIT_CHAIN_ID: 5
-DEPOSIT_NETWORK_ID: 5
-# Pyrmont test deposit contract on Goerli (2nd edition, 0x00002009 fork version)
-DEPOSIT_CONTRACT_ADDRESS: 0x8c5fecdC472E27Bc447696F431E425D02dd46a8c
-
-
-# Gwei values
-# ---------------------------------------------------------------
-# 2**0 * 10**9 (= 1,000,000,000) Gwei
-MIN_DEPOSIT_AMOUNT: 1000000000
-# 2**5 * 10**9 (= 32,000,000,000) Gwei
-MAX_EFFECTIVE_BALANCE: 32000000000
-# 2**4 * 10**9 (= 16,000,000,000) Gwei
-EJECTION_BALANCE: 16000000000
-# 2**0 * 10**9 (= 1,000,000,000) Gwei
-EFFECTIVE_BALANCE_INCREMENT: 1000000000
-
-
-# Initial values
-# ---------------------------------------------------------------
 # Pyrmont area code
 GENESIS_FORK_VERSION: 0x00002009
-BLS_WITHDRAWAL_PREFIX: 0x00
+# Customized for Pyrmont: 432000 seconds (5 days)
+GENESIS_DELAY: 432000
+
+
+# Forking
+# ---------------------------------------------------------------
+# Some forks are disabled for now:
+#  - These may be re-assigned to another fork-version later
+#  - Temporarily set to max uint64 value: 2**64 - 1
+
+# Altair
+ALTAIR_FORK_VERSION: 0x01002009
+ALTAIR_FORK_EPOCH: 61650
+# Merge
+MERGE_FORK_VERSION: 0x02002009
+MERGE_FORK_EPOCH: 18446744073709551615
+# Sharding
+SHARDING_FORK_VERSION: 0x03002009
+SHARDING_FORK_EPOCH: 18446744073709551615
+
+# TBD, 2**32 is a placeholder. Merge transition approach is in active R&D.
+TRANSITION_TOTAL_DIFFICULTY: 4294967296
 
 
 # Time parameters
 # ---------------------------------------------------------------
-# Customized for Pyrmont: 432000 seconds (5 days)
-GENESIS_DELAY: 432000
 # 12 seconds
 SECONDS_PER_SLOT: 12
-# 2**0 (= 1) slots 12 seconds
-MIN_ATTESTATION_INCLUSION_DELAY: 1
-# 2**5 (= 32) slots 6.4 minutes
-SLOTS_PER_EPOCH: 32
-# 2**0 (= 1) epochs 6.4 minutes
-MIN_SEED_LOOKAHEAD: 1
-# 2**2 (= 4) epochs 25.6 minutes
-MAX_SEED_LOOKAHEAD: 4
-# 2**6 (= 64) epochs ~6.8 hours
-EPOCHS_PER_ETH1_VOTING_PERIOD: 64
-# 2**13 (= 8,192) slots ~13 hours
-SLOTS_PER_HISTORICAL_ROOT: 8192
+# 14 (estimate from Eth1 mainnet)
+SECONDS_PER_ETH1_BLOCK: 14
 # 2**8 (= 256) epochs ~27 hours
 MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 256
 # 2**8 (= 256) epochs ~27 hours
 SHARD_COMMITTEE_PERIOD: 256
-# 2**2 (= 4) epochs 25.6 minutes
-MIN_EPOCHS_TO_INACTIVITY_PENALTY: 4
+# 2**11 (= 2,048) Eth1 blocks ~8 hours
+ETH1_FOLLOW_DISTANCE: 2048
 
 
-# State vector lengths
+# Validator cycle
 # ---------------------------------------------------------------
-# 2**16 (= 65,536) epochs ~0.8 years
-EPOCHS_PER_HISTORICAL_VECTOR: 65536
-# 2**13 (= 8,192) epochs ~36 days
-EPOCHS_PER_SLASHINGS_VECTOR: 8192
-# 2**24 (= 16,777,216) historical roots, ~26,131 years
-HISTORICAL_ROOTS_LIMIT: 16777216
-# 2**40 (= 1,099,511,627,776) validator spots
-VALIDATOR_REGISTRY_LIMIT: 1099511627776
-
-
-# Reward and penalty quotients
-# ---------------------------------------------------------------
-# 2**6 (= 64)
-BASE_REWARD_FACTOR: 64
-# 2**9 (= 512)
-WHISTLEBLOWER_REWARD_QUOTIENT: 512
-# 2**3 (= 8)
-PROPOSER_REWARD_QUOTIENT: 8
-# 2**26 (= 67,108,864)
-INACTIVITY_PENALTY_QUOTIENT: 67108864
-# 2**7 (= 128) (lower safety margin at Phase 0 genesis)
-MIN_SLASHING_PENALTY_QUOTIENT: 128
-# 1 (lower safety margin at Phase 0 genesis)
-PROPORTIONAL_SLASHING_MULTIPLIER: 1
-
-
-# Max operations per block
-# ---------------------------------------------------------------
+# 2**2 (= 4)
+INACTIVITY_SCORE_BIAS: 4
 # 2**4 (= 16)
-MAX_PROPOSER_SLASHINGS: 16
-# 2**1 (= 2)
-MAX_ATTESTER_SLASHINGS: 2
-# 2**7 (= 128)
-MAX_ATTESTATIONS: 128
-# 2**4 (= 16)
-MAX_DEPOSITS: 16
-# 2**4 (= 16)
-MAX_VOLUNTARY_EXITS: 16
+INACTIVITY_SCORE_RECOVERY_RATE: 16
+# 2**4 * 10**9 (= 16,000,000,000) Gwei
+EJECTION_BALANCE: 16000000000
+# 2**2 (= 4)
+MIN_PER_EPOCH_CHURN_LIMIT: 4
+# 2**16 (= 65,536)
+CHURN_LIMIT_QUOTIENT: 65536
 
 
-# Signature domains
+# Deposit contract
 # ---------------------------------------------------------------
-DOMAIN_BEACON_PROPOSER: 0x00000000
-DOMAIN_BEACON_ATTESTER: 0x01000000
-DOMAIN_RANDAO: 0x02000000
-DOMAIN_DEPOSIT: 0x03000000
-DOMAIN_VOLUNTARY_EXIT: 0x04000000
-DOMAIN_SELECTION_PROOF: 0x05000000
-DOMAIN_AGGREGATE_AND_PROOF: 0x06000000
+# Ethereum PoW Mainnet
+DEPOSIT_CHAIN_ID: 5
+DEPOSIT_NETWORK_ID: 5
+# Pyrmont test deposit contract on Goerli (2nd edition, 0x00002009 fork version)
+DEPOSIT_CONTRACT_ADDRESS: 0x8c5fecdC472E27Bc447696F431E425D02dd46a8c

--- a/shared/pyrmont/config.yaml
+++ b/shared/pyrmont/config.yaml
@@ -65,7 +65,7 @@ CHURN_LIMIT_QUOTIENT: 65536
 
 # Deposit contract
 # ---------------------------------------------------------------
-# Ethereum PoW Mainnet
+# Ethereum Goerli testnet
 DEPOSIT_CHAIN_ID: 5
 DEPOSIT_NETWORK_ID: 5
 # Pyrmont test deposit contract on Goerli (2nd edition, 0x00002009 fork version)


### PR DESCRIPTION
Sets the Altair fork epoch for Pyrmont and updates its config to preset based format.

Note that I've also set a custom fork version for the merge and sharding upgrades to ensure they're different from MainNet but those forks are not actually scheduled for Pyrmont yet and so those details may change again before they actually activate.